### PR TITLE
compileTestJava task failed; package org.openqa.selenium.devtools.v114.network does not exist

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/selenium-webdriver-junit4/build.gradle
+++ b/selenium-webdriver-junit4/build.gradle
@@ -137,4 +137,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-junit4/pom.xml
+++ b/selenium-webdriver-junit4/pom.xml
@@ -229,6 +229,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java
+++ b/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java
@@ -16,21 +16,21 @@
  */
 package io.github.bonigarcia.webdriver.junit4.ch10.mobile;
 
-import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class AppiumJUnit4Test {
 
@@ -41,12 +41,11 @@ public class AppiumJUnit4Test {
         URL appiumServerUrl = new URL("http://localhost:4723");
         assumeThat(isOnline(new URL(appiumServerUrl, "/status"))).isTrue();
 
-        ChromeOptions options = new ChromeOptions();
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        ChromiumOptions options = new ChromiumOptions();
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
 
         driver = new AppiumDriver(appiumServerUrl, options);
     }

--- a/selenium-webdriver-junit5-seljup/build.gradle
+++ b/selenium-webdriver-junit5-seljup/build.gradle
@@ -151,4 +151,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-junit5-seljup/pom.xml
+++ b/selenium-webdriver-junit5-seljup/pom.xml
@@ -274,6 +274,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch10/mobile/AppiumSelJupTest.java
+++ b/selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch10/mobile/AppiumSelJupTest.java
@@ -16,33 +16,33 @@
  */
 package io.github.bonigarcia.webdriver.seljup.ch10.mobile;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.chrome.ChromeOptions;
-
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
 import io.github.bonigarcia.seljup.DriverCapabilities;
 import io.github.bonigarcia.seljup.EnabledIfDriverUrlOnline;
 import io.github.bonigarcia.seljup.SeleniumJupiter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.Platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfDriverUrlOnline("http://localhost:4723")
 @ExtendWith(SeleniumJupiter.class)
 class AppiumSelJupTest {
 
     @DriverCapabilities
-    ChromeOptions options = new ChromeOptions();
+    ChromiumOptions options = new ChromiumOptions();
+
 
     @BeforeEach
     void setup() {
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
     }
 
     @Test

--- a/selenium-webdriver-junit5/build.gradle
+++ b/selenium-webdriver-junit5/build.gradle
@@ -142,4 +142,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-junit5/pom.xml
+++ b/selenium-webdriver-junit5/pom.xml
@@ -243,6 +243,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch10/mobile/AppiumJupiterTest.java
+++ b/selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch10/mobile/AppiumJupiterTest.java
@@ -16,21 +16,21 @@
  */
 package io.github.bonigarcia.webdriver.jupiter.ch10.mobile;
 
-import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 class AppiumJupiterTest {
 
@@ -41,12 +41,11 @@ class AppiumJupiterTest {
         URL appiumServerUrl = new URL("http://localhost:4723");
         assumeThat(isOnline(new URL(appiumServerUrl, "/status"))).isTrue();
 
-        ChromeOptions options = new ChromeOptions();
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        ChromiumOptions options = new ChromiumOptions();
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
 
         driver = new AppiumDriver(appiumServerUrl, options);
     }

--- a/selenium-webdriver-testng/build.gradle
+++ b/selenium-webdriver-testng/build.gradle
@@ -143,4 +143,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-testng/pom.xml
+++ b/selenium-webdriver-testng/pom.xml
@@ -229,6 +229,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch10/mobile/AppiumNGTest.java
+++ b/selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch10/mobile/AppiumNGTest.java
@@ -16,21 +16,21 @@
  */
 package io.github.bonigarcia.webdriver.testng.ch10.mobile;
 
-import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class AppiumNGTest {
 
@@ -41,12 +41,11 @@ public class AppiumNGTest {
         URL appiumServerUrl = new URL("http://localhost:4723");
         assumeThat(isOnline(new URL(appiumServerUrl, "/status"))).isTrue();
 
-        ChromeOptions options = new ChromeOptions();
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        ChromiumOptions options = new ChromiumOptions();
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
 
         driver = new AppiumDriver(appiumServerUrl, options);
     }


### PR DESCRIPTION
I cloned the master branch of the selenium-webdriver-java project. I installed JDK17. I modified "gradle-wrapper.properties" files so that I use Gradle 8.4 instead of 7.1

Then I tried to compile the test classes and got errors.

```
:~/github/selenium-webdriver-java/selenium-webdriver-junit4 (kazurayam4 *)
$ gradle compileTestJava

> Task :selenium-webdriver-junit4:compileTestJava
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/DeviceEmulationJUnit4Test.java:34: error: package org.openqa.selenium.devtools.v114.network does not exist
import org.openqa.selenium.devtools.v114.network.Network;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/EmulateNetworkConditionsJUnit4Test.java:32: error: package org.openqa.selenium.devtools.v114.network does not exist
import org.openqa.selenium.devtools.v114.network.Network;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/EmulateNetworkConditionsJUnit4Test.java:33: error: package org.openqa.selenium.devtools.v114.network.model does not exist
import org.openqa.selenium.devtools.v114.network.model.ConnectionType;
                                                      ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:36: error: package org.openqa.selenium.devtools.v114.dom.model does not exist
import org.openqa.selenium.devtools.v114.dom.model.Rect;
                                                  ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:37: error: package org.openqa.selenium.devtools.v114.page does not exist
import org.openqa.selenium.devtools.v114.page.Page;
                                             ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:38: error: package org.openqa.selenium.devtools.v114.page.Page does not exist
import org.openqa.selenium.devtools.v114.page.Page.GetLayoutMetricsResponse;
                                                  ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:39: error: package org.openqa.selenium.devtools.v114.page.model does not exist
import org.openqa.selenium.devtools.v114.page.model.Viewport;
                                                   ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/NetworkMonitoringJUnit4Test.java:31: error: package org.openqa.selenium.devtools.v114.network does not exist
import org.openqa.selenium.devtools.v114.network.Network;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/NetworkMonitoringJUnit4Test.java:32: error: package org.openqa.selenium.devtools.v114.network.model does not exist
import org.openqa.selenium.devtools.v114.network.model.Headers;
                                                      ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/NetworkMonitoringJUnit4Test.java:81: error: cannot find symbol
    void logHeaders(Headers headers) {
                    ^
  symbol:   class Headers
  location: class NetworkMonitoringJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/GeolocationOverrideJUnit4Test.java:30: error: package org.openqa.selenium.devtools.v114.emulation does not exist
import org.openqa.selenium.devtools.v114.emulation.Emulation;
                                                  ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:36: error: package org.openqa.selenium.devtools.v114.network does not exist
import org.openqa.selenium.devtools.v114.network.Network;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:37: error: package org.openqa.selenium.devtools.v114.network.model does not exist
import org.openqa.selenium.devtools.v114.network.model.Cookie;
                                                      ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:38: error: package org.openqa.selenium.devtools.v114.storage does not exist
import org.openqa.selenium.devtools.v114.storage.Storage;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/LoadInsecureJUnit4Test.java:32: error: package org.openqa.selenium.devtools.v114.security does not exist
import org.openqa.selenium.devtools.v114.security.Security;
                                                 ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:32: error: package org.openqa.selenium.devtools.v114.network does not exist
import org.openqa.selenium.devtools.v114.network.Network;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:33: error: package org.openqa.selenium.devtools.v114.network.model does not exist
import org.openqa.selenium.devtools.v114.network.model.BlockedReason;
                                                      ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ExtraHeadersJUnit4Test.java:35: error: package org.openqa.selenium.devtools.v114.network does not exist
import org.openqa.selenium.devtools.v114.network.Network;
                                                ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ExtraHeadersJUnit4Test.java:36: error: package org.openqa.selenium.devtools.v114.network.model does not exist
import org.openqa.selenium.devtools.v114.network.model.Headers;
                                                      ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/PerformanceMetricsJUnit4Test.java:33: error: package org.openqa.selenium.devtools.v114.performance does not exist
import org.openqa.selenium.devtools.v114.performance.Performance;
                                                    ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/PerformanceMetricsJUnit4Test.java:34: error: package org.openqa.selenium.devtools.v114.performance.model does not exist
import org.openqa.selenium.devtools.v114.performance.model.Metric;
                                                          ^
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:33: error: cannot find symbol
import io.appium.java_client.remote.MobileCapabilityType;
                                   ^
  symbol:   class MobileCapabilityType
  location: package io.appium.java_client.remote
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/DeviceEmulationJUnit4Test.java:69: error: cannot find symbol
        devTools.send(Network.setUserAgentOverride(userAgent, Optional.empty(),
                      ^
  symbol:   variable Network
  location: class DeviceEmulationJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/EmulateNetworkConditionsJUnit4Test.java:61: error: cannot find symbol
        devTools.send(Network.enable(Optional.empty(), Optional.empty(),
                      ^
  symbol:   variable Network
  location: class EmulateNetworkConditionsJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/EmulateNetworkConditionsJUnit4Test.java:63: error: cannot find symbol
        devTools.send(Network.emulateNetworkConditions(false, 100, 50 * 1024,
                      ^
  symbol:   variable Network
  location: class EmulateNetworkConditionsJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/EmulateNetworkConditionsJUnit4Test.java:64: error: cannot find symbol
                50 * 1024, Optional.of(ConnectionType.CELLULAR3G)));
                                       ^
  symbol:   variable ConnectionType
  location: class EmulateNetworkConditionsJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:72: error: cannot find symbol
        GetLayoutMetricsResponse metrics = devTools
        ^
  symbol:   class GetLayoutMetricsResponse
  location: class FullPageScreenshotChromeJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:73: error: cannot find symbol
                .send(Page.getLayoutMetrics());
                      ^
  symbol:   variable Page
  location: class FullPageScreenshotChromeJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:74: error: cannot find symbol
        Rect contentSize = metrics.getContentSize();
        ^
  symbol:   class Rect
  location: class FullPageScreenshotChromeJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:76: error: cannot find symbol
                .send(Page.captureScreenshot(Optional.empty(), Optional.empty(),
                      ^
  symbol:   variable Page
  location: class FullPageScreenshotChromeJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/FullPageScreenshotChromeJUnit4Test.java:77: error: cannot find symbol
                        Optional.of(new Viewport(0, 0, contentSize.getWidth(),
                                        ^
  symbol:   class Viewport
  location: class FullPageScreenshotChromeJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/NetworkMonitoringJUnit4Test.java:60: error: cannot find symbol
        devTools.send(Network.enable(Optional.empty(), Optional.empty(),
                      ^
  symbol:   variable Network
  location: class NetworkMonitoringJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/NetworkMonitoringJUnit4Test.java:63: error: cannot find symbol
        devTools.addListener(Network.requestWillBeSent(), request -> {
                             ^
  symbol:   variable Network
  location: class NetworkMonitoringJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/NetworkMonitoringJUnit4Test.java:70: error: cannot find symbol
        devTools.addListener(Network.responseReceived(), response -> {
                             ^
  symbol:   variable Network
  location: class NetworkMonitoringJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/GeolocationOverrideJUnit4Test.java:60: error: cannot find symbol
        devTools.send(Emulation.setGeolocationOverride(Optional.of(48.8584),
                      ^
  symbol:   variable Emulation
  location: class GeolocationOverrideJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:69: error: cannot find symbol
        devTools.send(Network.enable(Optional.empty(), Optional.empty(),
                      ^
  symbol:   variable Network
  location: class ManageCookiesJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:75: error: cannot find symbol
        List<Cookie> cookies = devTools
             ^
  symbol:   class Cookie
  location: class ManageCookiesJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:76: error: cannot find symbol
                .send(Storage.getCookies(Optional.empty()));
                      ^
  symbol:   variable Storage
  location: class ManageCookiesJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:81: error: incompatible types: inference variable T has incompatible bounds
                .collect(Collectors.toList());
                        ^
    equality constraints: String
    lower bounds: Object
  where T is a type-variable:
    T extends Object declared in method <T>toList()
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:90: error: cannot find symbol
        devTools.send(Network.clearBrowserCookies());
                      ^
  symbol:   variable Network
  location: class ManageCookiesJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:91: error: cannot find symbol
        List<Cookie> cookiesAfterClearing = devTools
             ^
  symbol:   class Cookie
  location: class ManageCookiesJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ManageCookiesJUnit4Test.java:92: error: cannot find symbol
                .send(Storage.getCookies(Optional.empty()));
                      ^
  symbol:   variable Storage
  location: class ManageCookiesJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/LoadInsecureJUnit4Test.java:64: error: cannot find symbol
        devTools.send(Security.enable());
                      ^
  symbol:   variable Security
  location: class LoadInsecureJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/LoadInsecureJUnit4Test.java:65: error: cannot find symbol
        devTools.send(Security.setIgnoreCertificateErrors(true));
                      ^
  symbol:   variable Security
  location: class LoadInsecureJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:66: error: cannot find symbol
        devTools.send(Network.enable(Optional.empty(), Optional.empty(),
                      ^
  symbol:   variable Network
  location: class BlockUrlJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:70: error: cannot find symbol
        devTools.send(Network.setBlockedURLs(ImmutableList.of(urlToBlock)));
                      ^
  symbol:   variable Network
  location: class BlockUrlJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:72: error: cannot find symbol
        devTools.addListener(Network.loadingFailed(), loadingFailed -> {
                             ^
  symbol:   variable Network
  location: class BlockUrlJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:73: error: cannot find symbol
            BlockedReason reason = loadingFailed.getBlockedReason().get();
            ^
  symbol:   class BlockedReason
  location: class BlockUrlJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/BlockUrlJUnit4Test.java:75: error: cannot find symbol
            assertThat(reason).isEqualTo(BlockedReason.INSPECTOR);
                                         ^
  symbol:   variable BlockedReason
  location: class BlockUrlJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ExtraHeadersJUnit4Test.java:64: error: cannot find symbol
        devTools.send(Network.enable(Optional.empty(), Optional.empty(),
                      ^
  symbol:   variable Network
  location: class ExtraHeadersJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ExtraHeadersJUnit4Test.java:73: error: cannot find symbol
        devTools.send(Network.setExtraHTTPHeaders(new Headers(headers)));
                                                      ^
  symbol:   class Headers
  location: class ExtraHeadersJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/ExtraHeadersJUnit4Test.java:73: error: cannot find symbol
        devTools.send(Network.setExtraHTTPHeaders(new Headers(headers)));
                      ^
  symbol:   variable Network
  location: class ExtraHeadersJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/PerformanceMetricsJUnit4Test.java:65: error: cannot find symbol
        devTools.send(Performance.enable(Optional.empty()));
                      ^
  symbol:   variable Performance
  location: class PerformanceMetricsJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/PerformanceMetricsJUnit4Test.java:68: error: cannot find symbol
        List<Metric> metrics = devTools.send(Performance.getMetrics());
             ^
  symbol:   class Metric
  location: class PerformanceMetricsJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch05/cdp/PerformanceMetricsJUnit4Test.java:68: error: cannot find symbol
        List<Metric> metrics = devTools.send(Performance.getMetrics());
                                             ^
  symbol:   variable Performance
  location: class PerformanceMetricsJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:45: error: cannot find symbol
        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
                              ^
  symbol:   variable MobileCapabilityType
  location: class AppiumJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:46: error: cannot find symbol
        options.setCapability(MobileCapabilityType.DEVICE_NAME,
                              ^
  symbol:   variable MobileCapabilityType
  location: class AppiumJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:48: error: cannot find symbol
        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
                              ^
  symbol:   variable MobileCapabilityType
  location: class AppiumJUnit4Test
58 errors

> Task :selenium-webdriver-junit4:compileTestJava FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':selenium-webdriver-junit4:compileTestJava'.
> Compilation failed; see the compiler error output for details.

* Try:
> Run with --info option to get more log output.
> Run with --scan to get full insights.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 9.0.

You can use '--warning-mode all' to show the individual deprecation warnings and determine if they come from your own scripts or plugins.

For more on this, please refer to https://docs.gradle.org/8.4/userguide/command_line_interface.html#sec:command_line_warnings in the Gradle documentation.

BUILD FAILED in 3s
3 actionable tasks: 1 executed, 2 up-to-date
```

I looked at the 4 build.gradle files and the 4 pom.xml files. I found that I should insert the following dependency declarations:

for the Maven pom.xml files
```
<!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
<dependency>
    <groupId>org.seleniumhq.selenium</groupId>
    <artifactId>selenium-devtools-v114</artifactId>
    <version>4.12.1</version>
</dependency>
```

for the Gradle build.gradle files:
```
// https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
```

See https://github.com/kazurayam/selenium-webdriver-java/issues/4 for what I have done
