### PR TITLE
compileTestJava task failed; cannot find symbol import io.appium.java_client.remote.MobileCapabilityType

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/selenium-webdriver-junit4/build.gradle
+++ b/selenium-webdriver-junit4/build.gradle
@@ -137,4 +137,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-junit4/pom.xml
+++ b/selenium-webdriver-junit4/pom.xml
@@ -229,6 +229,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java
+++ b/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java
@@ -16,21 +16,21 @@
  */
 package io.github.bonigarcia.webdriver.junit4.ch10.mobile;
 
-import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class AppiumJUnit4Test {
 
@@ -41,12 +41,11 @@ public class AppiumJUnit4Test {
         URL appiumServerUrl = new URL("http://localhost:4723");
         assumeThat(isOnline(new URL(appiumServerUrl, "/status"))).isTrue();
 
-        ChromeOptions options = new ChromeOptions();
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        ChromiumOptions options = new ChromiumOptions();
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
 
         driver = new AppiumDriver(appiumServerUrl, options);
     }

--- a/selenium-webdriver-junit5-seljup/build.gradle
+++ b/selenium-webdriver-junit5-seljup/build.gradle
@@ -151,4 +151,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-junit5-seljup/pom.xml
+++ b/selenium-webdriver-junit5-seljup/pom.xml
@@ -274,6 +274,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch10/mobile/AppiumSelJupTest.java
+++ b/selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch10/mobile/AppiumSelJupTest.java
@@ -16,33 +16,33 @@
  */
 package io.github.bonigarcia.webdriver.seljup.ch10.mobile;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.openqa.selenium.chrome.ChromeOptions;
-
 import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
 import io.github.bonigarcia.seljup.DriverCapabilities;
 import io.github.bonigarcia.seljup.EnabledIfDriverUrlOnline;
 import io.github.bonigarcia.seljup.SeleniumJupiter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.openqa.selenium.Platform;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @EnabledIfDriverUrlOnline("http://localhost:4723")
 @ExtendWith(SeleniumJupiter.class)
 class AppiumSelJupTest {
 
     @DriverCapabilities
-    ChromeOptions options = new ChromeOptions();
+    ChromiumOptions options = new ChromiumOptions();
+
 
     @BeforeEach
     void setup() {
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
     }
 
     @Test

--- a/selenium-webdriver-junit5/build.gradle
+++ b/selenium-webdriver-junit5/build.gradle
@@ -142,4 +142,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-junit5/pom.xml
+++ b/selenium-webdriver-junit5/pom.xml
@@ -243,6 +243,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch10/mobile/AppiumJupiterTest.java
+++ b/selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch10/mobile/AppiumJupiterTest.java
@@ -16,21 +16,21 @@
  */
 package io.github.bonigarcia.webdriver.jupiter.ch10.mobile;
 
-import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.openqa.selenium.Platform;
+import org.openqa.selenium.WebDriver;
 
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
-import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
-
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 class AppiumJupiterTest {
 
@@ -41,12 +41,11 @@ class AppiumJupiterTest {
         URL appiumServerUrl = new URL("http://localhost:4723");
         assumeThat(isOnline(new URL(appiumServerUrl, "/status"))).isTrue();
 
-        ChromeOptions options = new ChromeOptions();
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        ChromiumOptions options = new ChromiumOptions();
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
 
         driver = new AppiumDriver(appiumServerUrl, options);
     }

--- a/selenium-webdriver-testng/build.gradle
+++ b/selenium-webdriver-testng/build.gradle
@@ -143,4 +143,7 @@ dependencies {
         exclude group: "org.seleniumhq.selenium", module: "*"
     }
     testImplementation("io.rest-assured:rest-assured:${restAssuredVersion}")
+
+    // https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114
+    testImplementation 'org.seleniumhq.selenium:selenium-devtools-v114:4.12.1'
 }

--- a/selenium-webdriver-testng/pom.xml
+++ b/selenium-webdriver-testng/pom.xml
@@ -229,6 +229,12 @@
             <version>${rest-assured.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.seleniumhq.selenium/selenium-devtools-v114 -->
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-devtools-v114</artifactId>
+            <version>4.12.1</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch10/mobile/AppiumNGTest.java
+++ b/selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch10/mobile/AppiumNGTest.java
@@ -16,21 +16,21 @@
  */
 package io.github.bonigarcia.webdriver.testng.ch10.mobile;
 
-import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-
+import io.appium.java_client.AppiumDriver;
+import io.appium.java_client.chromium.options.ChromiumOptions;
+import io.appium.java_client.remote.AutomationName;
+import org.openqa.selenium.Platform;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.chrome.ChromeOptions;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import io.appium.java_client.AppiumDriver;
-import io.appium.java_client.remote.MobileCapabilityType;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static io.github.bonigarcia.wdm.WebDriverManager.isOnline;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 public class AppiumNGTest {
 
@@ -41,12 +41,11 @@ public class AppiumNGTest {
         URL appiumServerUrl = new URL("http://localhost:4723");
         assumeThat(isOnline(new URL(appiumServerUrl, "/status"))).isTrue();
 
-        ChromeOptions options = new ChromeOptions();
-        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
-        options.setCapability(MobileCapabilityType.DEVICE_NAME,
+        ChromiumOptions options = new ChromiumOptions();
+        options.setPlatformName(Platform.ANDROID.name())
+                .setAutomationName(AutomationName.ANDROID_UIAUTOMATOR2);
+        options.setCapability("deviceName",
                 "Nexus 5 API 30");
-        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
-                "UiAutomator2");
 
         driver = new AppiumDriver(appiumServerUrl, options);
     }


### PR DESCRIPTION
I got the following comilation errors:

```
:~/github/selenium-webdriver-java (kazurayam4)
$ ./gradlew build

> Task :selenium-webdriver-junit4:compileTestJava
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:33: error: cannot find symbol
import io.appium.java_client.remote.MobileCapabilityType;
                                   ^
  symbol:   class MobileCapabilityType
  location: package io.appium.java_client.remote
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:45: error: cannot find symbol
        options.setCapability(MobileCapabilityType.PLATFORM_NAME, "Android");
                              ^
  symbol:   variable MobileCapabilityType
  location: class AppiumJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:46: error: cannot find symbol
        options.setCapability(MobileCapabilityType.DEVICE_NAME,
                              ^
  symbol:   variable MobileCapabilityType
  location: class AppiumJUnit4Test
/Users/kazuakiurayama/github/selenium-webdriver-java/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java:48: error: cannot find symbol
        options.setCapability(MobileCapabilityType.AUTOMATION_NAME,
                              ^
  symbol:   variable MobileCapabilityType
  location: class AppiumJUnit4Test
4 errors

> Task :selenium-webdriver-junit4:compileTestJava FAILED
```

----

The Appium java-client v9.0.0 was just recently released at 13 Oct 2023 

https://github.com/appium/java-client/releases/tag/v9.0.0

This icludes a breaking change:

>The previously deprecated MobileCapabilityType interface has been removed. Use driver options instead

The upgrade of Appium java-client v8.6.0 to v9.0.0 has broken the https://github.com/bonigarcia/selenium-webdriver-java, tag 1.3.0

----

Therefore we need to change following source files if we are to use the Appium java-client v9.0.0

- selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch10/mobile/AppiumJUnit4Test.java
- selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch10/mobile/AppiumSelJupTest.java
- selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch10/mobile/AppiumJupiterTest.java
- selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch10/mobile/AppiumNGTest.java

How to change the code? See https://github.com/kazurayam/selenium-webdriver-java/issues/5 for what I have done

I changed the code a bit significantly. I swapped the class to use. 

But I haven't checked if the description in the Book is consistent with the changed code.
