### PR TITLE
enhancement: Use Relative Locators in DatePicker

### DIFF
--- a/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch03/locators_relative/DatePickerJUnit4Test.java
+++ b/selenium-webdriver-junit4/src/test/java/io/github/bonigarcia/webdriver/junit4/ch03/locators_relative/DatePickerJUnit4Test.java
@@ -69,9 +69,13 @@ public class DatePickerJUnit4Test {
                 String.format("//th[contains(text(),'%d')]", currentYear)));
         monthElement.click();
 
-        // Click on the left arrow
-        WebElement arrowLeft = driver.findElement(By.cssSelector(
-                "div[class='datepicker-months'] th[class='prev']"));
+        // Get the element to look for with relative locator
+        WebElement yearElement = driver.findElement(By.xpath(
+                String.format("//th[@class='datepicker-switch' and text()='%d']", currentYear)));
+
+        // Click on the left arrow using relative locators
+        WebElement arrowLeft = driver.findElement(
+                RelativeLocator.with(By.tagName("th")).toLeftOf(yearElement));
         arrowLeft.click();
 
         // Click on the current month of that year

--- a/selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch03/locators_relative/DatePickerSelJupTest.java
+++ b/selenium-webdriver-junit5-seljup/src/test/java/io/github/bonigarcia/webdriver/seljup/ch03/locators_relative/DatePickerSelJupTest.java
@@ -57,9 +57,13 @@ class DatePickerSelJupTest {
                 String.format("//th[contains(text(),'%d')]", currentYear)));
         monthElement.click();
 
-        // Click on the left arrow
-        WebElement arrowLeft = driver.findElement(By.cssSelector(
-                "div[class='datepicker-months'] th[class='prev']"));
+        // Get the element to look for with relative locator
+        WebElement yearElement = driver.findElement(By.xpath(
+                String.format("//th[@class='datepicker-switch' and text()='%d']", currentYear)));
+
+        // Click on the left arrow using relative locators
+        WebElement arrowLeft = driver.findElement(
+                RelativeLocator.with(By.tagName("th")).toLeftOf(yearElement));
         arrowLeft.click();
 
         // Click on the current month of that year

--- a/selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch03/locators_relative/DatePickerJupiterTest.java
+++ b/selenium-webdriver-junit5/src/test/java/io/github/bonigarcia/webdriver/jupiter/ch03/locators_relative/DatePickerJupiterTest.java
@@ -69,9 +69,13 @@ class DatePickerJupiterTest {
                 String.format("//th[contains(text(),'%d')]", currentYear)));
         monthElement.click();
 
-        // Click on the left arrow
-        WebElement arrowLeft = driver.findElement(By.cssSelector(
-                "div[class='datepicker-months'] th[class='prev']"));
+        // Get the element to look for with relative locator
+        WebElement yearElement = driver.findElement(By.xpath(
+                String.format("//th[@class='datepicker-switch' and text()='%d']", currentYear)));
+
+        // Click on the left arrow using relative locators
+        WebElement arrowLeft = driver.findElement(
+                RelativeLocator.with(By.tagName("th")).toLeftOf(yearElement));
         arrowLeft.click();
 
         // Click on the current month of that year

--- a/selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch03/locators_relative/DatePickerNGTest.java
+++ b/selenium-webdriver-testng/src/test/java/io/github/bonigarcia/webdriver/testng/ch03/locators_relative/DatePickerNGTest.java
@@ -69,9 +69,13 @@ public class DatePickerNGTest {
                 String.format("//th[contains(text(),'%d')]", currentYear)));
         monthElement.click();
 
-        // Click on the left arrow
-        WebElement arrowLeft = driver.findElement(By.cssSelector(
-                "div[class='datepicker-months'] th[class='prev']"));
+        // Get the element to look for with relative locator
+        WebElement yearElement = driver.findElement(By.xpath(
+                String.format("//th[@class='datepicker-switch' and text()='%d']", currentYear)));
+
+        // Click on the left arrow using relative locators
+        WebElement arrowLeft = driver.findElement(
+                RelativeLocator.with(By.tagName("th")).toLeftOf(yearElement));
         arrowLeft.click();
 
         // Click on the current month of that year


### PR DESCRIPTION
## Summary

This pull request updates the `DatePicker` example to use **relative locators**, as intended in Chapter 3 of the book.

While the current fix in this repository uses a direct CSS selector, this change restores the use of `RelativeLocator.with(...)`, which better aligns with the educational focus of the chapter.

---

## Changes Made

- Locate the year element using `By.xpath` based on the current year.
- Use `RelativeLocator.with(By.tagName("th")).toLeftOf(yearElement)` to select the left arrow (`prev`) element.

---

## Why This Matters

The book chapter is specifically about **relative locators**, so this fix helps maintain consistency between the lesson and the working code in the repo.

This version was tested and works correctly.

---

Closes #1229 